### PR TITLE
Fix typo in timeslot comment

### DIFF
--- a/src/tetra_common.h
+++ b/src/tetra_common.h
@@ -59,7 +59,7 @@ struct tetra_mac_state {
 
 	char *dumpdir;	/* Where to save traffic channel dump */
 	int ssi;	/* SSI */
-	int tsn;	/* Timeslon number */
+	int tsn;	/* Timeslot number */
 	int usage_marker; /* Usage marker (if addressed)*/
 	int addr_type;
 };


### PR DESCRIPTION
## Summary
- correct the `tsn` field comment in `tetra_common.h`

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_688707a08e1c832db77f328758137b57