### PR TITLE
Fix typo in receiver1udp error string

### DIFF
--- a/src/receiver1udp
+++ b/src/receiver1udp
@@ -65,7 +65,7 @@ case "$PYT" in
 		socat -b 4096 UDP-RECV:${UDP_PORT} STDOUT | demod/simdemod3.py | ./tetra-rx   /dev/stdin
 		;;
 	*)
-		echo "Dont know how to handle pythin version [$PYT]"
+                echo "Dont know how to handle python version [$PYT]"
 		exit 1
 esac
 


### PR DESCRIPTION
## Summary
- fix `pythin` -> `python` typo in src/receiver1udp

## Testing
- `make -C src`


------
https://chatgpt.com/codex/tasks/task_e_688707756e14832d8df0a509fe661998