### PR TITLE
Capture auth and OTAR messages

### DIFF
--- a/src/tetra_mle.c
+++ b/src/tetra_mle.c
@@ -30,31 +30,43 @@ int rx_tl_sdu(struct tetra_mac_state *tms, struct msgb *msg, unsigned int len)
         switch (mle_pdisc) {
         case TMLE_PDISC_MM: {
                 uint8_t pdut = bits_to_uint(bits+3, 4);
-                printf("%s\n", tetra_get_mm_pdut_name(pdut, 0));
-               if (pdut == TMM_PDU_T_D_AUTH) {
+                printf("%s ", tetra_get_mm_pdut_name(pdut, 0));
+                switch (pdut) {
+                case TMM_PDU_T_D_AUTH: {
                         struct msgb *gsmtap_msg;
                         struct tetra_tdma_time tm = t_phy_state.time;
                         uint8_t auth_sub_type;
-                        uint8_t rand1[10];
-                        uint8_t ra[10];
-
-                        const uint8_t *cur = bits + 3 + 4; /* skip PDISC and PDU type */
+                        const uint8_t *cur = bits + 3 + 4;
 
                         auth_sub_type = bits_to_uint(cur, 2);
                         cur += 2;
 
-                        for (int i = 0; i < 10; i++) {
-                                rand1[i] = bits_to_uint(cur, 8);
-                                cur += 8;
-                        }
-                        for (int i = 0; i < 10; i++) {
-                                ra[i] = bits_to_uint(cur, 8);
-                                cur += 8;
-                        }
+                        printf("%s", tetra_get_auth_sub_type_name(auth_sub_type));
 
-                        printf(" RAND1=%s RA=%s\n", osmo_hexdump(rand1, sizeof(rand1)),
-                               osmo_hexdump(ra, sizeof(ra)));
-
+                        if (auth_sub_type == TMM_AUTH_ST_DEMAND) {
+                                uint8_t rand1[10];
+                                uint8_t ra[10];
+                                for (int i = 0; i < 10; i++) {
+                                        rand1[i] = bits_to_uint(cur, 8);
+                                        cur += 8;
+                                }
+                                for (int i = 0; i < 10; i++) {
+                                        ra[i] = bits_to_uint(cur, 8);
+                                        cur += 8;
+                                }
+                                printf(" RAND1=%s RA=%s", osmo_hexdump(rand1, sizeof(rand1)),
+                                       osmo_hexdump(ra, sizeof(ra)));
+                        } else {
+                                int payload_bits = len - (3 + 4 + 2);
+                                int payload_bytes = (payload_bits + 7) / 8;
+                                uint8_t payload[256];
+                                for (int i = 0; i < payload_bytes; i++) {
+                                        payload[i] = bits_to_uint(cur, 8);
+                                        cur += 8;
+                                }
+                                printf(" DATA=%s", osmo_hexdump(payload, payload_bytes));
+                        }
+                        printf("\n");
 
                         /* Provide a timestamp close to the burst that carried
                          * the last fragment and ensure the timeslot is in the
@@ -64,10 +76,38 @@ int rx_tl_sdu(struct tetra_mac_state *tms, struct msgb *msg, unsigned int len)
                                                          0, 0, bits, len, tms);
                         if (gsmtap_msg)
                                 tetra_gsmtap_sendmsg(gsmtap_msg);
+                        break;
+                }
+                case TMM_PDU_T_D_OTAR: {
+                        struct msgb *gsmtap_msg;
+                        struct tetra_tdma_time tm = t_phy_state.time;
+                        const uint8_t *cur = bits + 3 + 4;
+                        uint8_t otar_sub_type = bits_to_uint(cur, 4);
+                        cur += 4;
+                        int payload_bits = len - (3 + 4 + 4);
+                        int payload_bytes = (payload_bits + 7) / 8;
+                        uint8_t payload[256];
+                        for (int i = 0; i < payload_bytes; i++) {
+                                payload[i] = bits_to_uint(cur, 8);
+                                cur += 8;
+                        }
+                        printf("%s DATA=%s\n", tetra_get_otar_sub_type_name(otar_sub_type),
+                               osmo_hexdump(payload, payload_bytes));
+
+                        gsmtap_msg = tetra_gsmtap_makemsg(&tm, TETRA_LC_STCH,
+                                                         tms->tsn - 1, 0,
+                                                         0, 0, bits, len, tms);
+                        if (gsmtap_msg)
+                                tetra_gsmtap_sendmsg(gsmtap_msg);
+                        break;
+                }
+                default:
+                        printf("\n");
+                        break;
                 }
                 break;
         }
-	case TMLE_PDISC_CMCE:
+        case TMLE_PDISC_CMCE:
 		printf("%s\n", tetra_get_cmce_pdut_name(bits_to_uint(bits+3, 5), 0));
 		break;
 	case TMLE_PDISC_SNDCP:

--- a/src/tetra_mm_pdu.c
+++ b/src/tetra_mm_pdu.c
@@ -41,6 +41,44 @@ static const struct value_string mm_pdut_d_names[] = {
 };
 const char *tetra_get_mm_pdut_name(uint8_t pdut, int uplink)
 {
-	/* FIXME: uplink */
-	return get_value_string(mm_pdut_d_names, pdut);
+        /* FIXME: uplink */
+        return get_value_string(mm_pdut_d_names, pdut);
+}
+
+static const struct value_string auth_sub_names[] = {
+       { TMM_AUTH_ST_DEMAND,   "Demand" },
+       { TMM_AUTH_ST_RESPONSE, "Response" },
+       { TMM_AUTH_ST_RESULT,   "Result" },
+       { TMM_AUTH_ST_REJECT,   "Reject" },
+       { 0, NULL }
+};
+
+const char *tetra_get_auth_sub_type_name(uint8_t sub_type)
+{
+       return get_value_string(auth_sub_names, sub_type);
+}
+
+static const struct value_string otar_sub_names[] = {
+       { TMM_OTAR_ST_CCK_PROVIDE,          "CCK Provide" },
+       { TMM_OTAR_ST_CCK_REJECT,           "CCK Reject" },
+       { TMM_OTAR_ST_SCK_PROVIDE,          "SCK Provide" },
+       { TMM_OTAR_ST_SCK_REJECT,           "SCK Reject" },
+       { TMM_OTAR_ST_GCK_PROVIDE,          "GCK Provide" },
+       { TMM_OTAR_ST_GCK_REJECT,           "GCK Reject" },
+       { TMM_OTAR_ST_KEY_ASSOCIATE_DEMAND, "Key associate Demand" },
+       { TMM_OTAR_ST_OTAR_NEWCELL,         "OTAR NEWCELL" },
+       { TMM_OTAR_ST_GSKO_PROVIDE,         "GSKO Provide" },
+       { TMM_OTAR_ST_GSKO_REJECT,          "GSKO Reject" },
+       { TMM_OTAR_ST_KEY_DELETE_DEMAND,    "Key delete demand" },
+       { TMM_OTAR_ST_KEY_STATUS_DEMAND,    "Key status demand" },
+       { TMM_OTAR_ST_CMG_GTSI_PROVIDE,     "CMG GTSI provide" },
+       { TMM_OTAR_ST_DM_SCK_ACTIVATE,      "DM SCK Activate" },
+       { TMM_OTAR_ST_RESERVED_14,          "Reserved 14" },
+       { TMM_OTAR_ST_RESERVED_15,          "Reserved 15" },
+       { 0, NULL }
+};
+
+const char *tetra_get_otar_sub_type_name(uint8_t sub_type)
+{
+       return get_value_string(otar_sub_names, sub_type);
 }

--- a/src/tetra_mm_pdu.h
+++ b/src/tetra_mm_pdu.h
@@ -21,6 +21,34 @@ enum tetra_mm_pdu_type_d {
 	TMM_PDU_T_D_MM_PDU_NOTSUPP	= 0xf
 };
 
+/* Authentication PDU subtypes */
+enum tetra_auth_sub_type {
+       TMM_AUTH_ST_DEMAND = 0,
+       TMM_AUTH_ST_RESPONSE = 1,
+       TMM_AUTH_ST_RESULT = 2,
+       TMM_AUTH_ST_REJECT = 3,
+};
+
+/* OTAR PDU subtypes */
+enum tetra_otar_sub_type {
+       TMM_OTAR_ST_CCK_PROVIDE = 0,
+       TMM_OTAR_ST_CCK_REJECT,
+       TMM_OTAR_ST_SCK_PROVIDE,
+       TMM_OTAR_ST_SCK_REJECT,
+       TMM_OTAR_ST_GCK_PROVIDE,
+       TMM_OTAR_ST_GCK_REJECT,
+       TMM_OTAR_ST_KEY_ASSOCIATE_DEMAND,
+       TMM_OTAR_ST_OTAR_NEWCELL,
+       TMM_OTAR_ST_GSKO_PROVIDE,
+       TMM_OTAR_ST_GSKO_REJECT,
+       TMM_OTAR_ST_KEY_DELETE_DEMAND,
+       TMM_OTAR_ST_KEY_STATUS_DEMAND,
+       TMM_OTAR_ST_CMG_GTSI_PROVIDE,
+       TMM_OTAR_ST_DM_SCK_ACTIVATE,
+       TMM_OTAR_ST_RESERVED_14,
+       TMM_OTAR_ST_RESERVED_15,
+};
+
 /* 16.10.35a Location update accept type */
 enum tetra_mm_loc_upd_acc_type {
 	TMM_LUPD_ACC_T_ROAMING		= 0,
@@ -34,5 +62,7 @@ enum tetra_mm_loc_upd_acc_type {
 };
 
 const char *tetra_get_mm_pdut_name(uint8_t pdut, int uplink);
+const char *tetra_get_auth_sub_type_name(uint8_t sub_type);
+const char *tetra_get_otar_sub_type_name(uint8_t sub_type);
 
 #endif


### PR DESCRIPTION
## Summary
- add enums for authentication and OTAR MM subtypes
- capture and log authentication and OTAR TL-SDUs, forwarding to GSMTAP

## Testing
- `make`
- `./tetra-rx-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a2b2ea4918832db4b3d58b30badfd8